### PR TITLE
chore(ci): bump actions/checkout from v2 to v7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
 
       - name: Set up nodejs
         uses: actions/setup-node@v2
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
 
       - name: Set up nodejs
         uses: actions/setup-node@v2

--- a/.github/workflows/publish-beta-package.yml
+++ b/.github/workflows/publish-beta-package.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/publish-release-package.yml
+++ b/.github/workflows/publish-release-package.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
 
       - name: Set up nodejs
         uses: actions/setup-node@v2


### PR DESCRIPTION
## Summary
- Bumps `actions/checkout` from `@v2` to `@v7` (current stable release).
- `v2` is well past EOL; `v7` is the current major version.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>